### PR TITLE
Changes survey sorting link to close #191

### DIFF
--- a/_episodes/04-quality-control.md
+++ b/_episodes/04-quality-control.md
@@ -110,7 +110,7 @@ If your dataset is well-structured and does not contain formulas, sorting should
 
 > ## Exercise   
 >
-> We've combined all of the tables from the messy data into a single table in a single tab. Download this semi-cleaned data file to your computer: [survey_sorting_exercise](https://figshare.com/articles/survey_data_messy_quality_control/4830016)
+> We've combined all of the tables from the messy data into a single table in a single tab. Download this semi-cleaned data file to your computer: [survey_sorting_exercise](https://github.com/datacarpentry/spreadsheet-ecology-lesson/blob/gh-pages/data/survey_data_spreadsheet_messy.xls?raw=true)
 >
 > Once downloaded, sort the `Weight_grams` column in your spreadsheet program from `Largest to Smallest`. 
 >


### PR DESCRIPTION
Just reading the issues, it seems like this link was never changed. The new link given by @primerano elicits an automatic download. 
(https://github.com/datacarpentry/spreadsheet-ecology-lesson/blob/gh-pages/data/survey_data_spreadsheet_messy.xls?raw=true)
@ErinBecker I hope I'm not jumping in too soon.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
